### PR TITLE
Improve PHPUnit namespace and fixtures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "metasyntactical/io": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Exception/FileNotFoundExceptionTest.php
+++ b/tests/Exception/FileNotFoundExceptionTest.php
@@ -3,8 +3,9 @@
 namespace MetaSyntactical\Mime\Exception;
 
 use RuntimeException;
+use PHPUnit\Framework\TestCase;
 
-class FileNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+class FileNotFoundExceptionTest extends TestCase
 {
     /**
      * @var FileNotFoundException
@@ -15,7 +16,7 @@ class FileNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
      * Sets up the fixture, for example, opens a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->object = new FileNotFoundException;
     }
@@ -24,7 +25,7 @@ class FileNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
      * Tears down the fixture, for example, closes a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
     }
 


### PR DESCRIPTION
# Changed log

- Using `PHPUnit\Framework\TestCase` namespace.
- Using the `phpunit:^8.0` version for `php-7.2+` version.
- Using the `protected function setUp(): void` to be compatible with `PHPUnit:^8.0` version.